### PR TITLE
feat: Create frontend styling documentation

### DIFF
--- a/FRONTEND_STYLING.md
+++ b/FRONTEND_STYLING.md
@@ -1,0 +1,43 @@
+# Frontend Styling Documentation
+
+This document outlines the current styling architecture of the frontend application. It is intended to assist in a potential migration to a new styling system, such as Tailwind CSS with DaisyUI.
+
+## 1. Global Styling
+
+The primary source of styling for the application is the global CSS file located at `dashboard-ui/public/styles.css`. This file is responsible for:
+
+- **Basic Resets:** A simple reset is applied to `body` and `html` to remove default margins and padding.
+- **Font Definitions:** The default font for the application is set to a system font stack.
+- **Main Layout:** The file defines the main layout structure of the application, which consists of a sidebar and a content area. The layout is implemented using Flexbox, with the main container being `.dashboard-container`, and the two children being `.sidebar` and `.content`.
+- **Basic Component Styling:** The file also contains basic styling for some components, such as the navigation links in the sidebar.
+
+## 2. Component-Specific Styling
+
+In addition to the global stylesheet, some components have their own styles that are dynamically injected into the document's `<head>` as a `<style>` tag. This is a form of CSS-in-JS, but implemented manually without a library.
+
+A good example of this is the `StatusCard` component, located in `dashboard-ui/src/components/StatusCard.js`. The `createStatusCard` function in this file creates a new `<style>` element with the CSS for the status card and appends it to the document head.
+
+This approach encapsulates the component's styles within the same file as its logic, but it can also lead to duplicated styles if the same component is used multiple times on the same page.
+
+## 3. Inline Styles
+
+Inline styles are used for dynamic styling that needs to change based on the component's state. For example, in the `StatusCard` component, the `backgroundColor` of the status light is set directly on the element using inline styles.
+
+This is a common pattern for styles that are determined at runtime, but it can make the code harder to read and maintain if overused.
+
+## 4. Theming
+
+The application has a simple theming system that is implemented in `dashboard-ui/src/theme.js`. This script listens for changes on a theme dropdown and sets a `data-theme` attribute on the `<html>` element.
+
+The actual theme styles are likely defined in a CSS file (presumably `styles.css`) using attribute selectors, like `html[data-theme="dark"]`. This allows the styles to be changed dynamically based on the selected theme.
+
+## 5. Summary and Recommendations for Migration
+
+The current styling system is a mix of global CSS, manually implemented CSS-in-JS, and inline styles. While this system works, it can be difficult to maintain and scale.
+
+For a migration to Tailwind CSS and DaisyUI, the following steps are recommended:
+
+- **Replace Global Styles with Utility Classes:** The styles in `dashboard-ui/public/styles.css` can be replaced with Tailwind's utility classes. For example, the Flexbox layout can be implemented using classes like `flex`, `flex-row`, and `flex-grow`.
+- **Convert Component-Specific Styles to Tailwind Components:** The dynamically injected styles for components like `StatusCard` can be converted to Tailwind components. This can be done by creating a new CSS file and using Tailwind's `@apply` directive to create component classes, or by simply using utility classes directly in the HTML.
+- **Use DaisyUI for Common Components:** DaisyUI provides a set of pre-built components that can be used to replace many of the custom components in the application. This will help to speed up the migration and ensure a consistent design.
+- **Leverage DaisyUI's Theming System:** DaisyUI has a robust theming system that can be used to replace the custom theming implementation. This will make it easier to manage themes and add new ones in the future.


### PR DESCRIPTION
This commit adds a new file, `FRONTEND_STYLING.md`, which documents the current frontend styling architecture.

The document covers:
- Global styling using a CSS file.
- Component-specific styling using dynamically injected style tags.
- The use of inline styles for dynamic properties.
- The theming implementation.

It also provides recommendations for a future migration to a more modern styling system like Tailwind CSS and DaisyUI.